### PR TITLE
Fix: handle possibly not existing array property access

### DIFF
--- a/lib/object-get.js
+++ b/lib/object-get.js
@@ -46,7 +46,7 @@ function objectGet (object, expression) {
   return expression.trim().split('.').reduce(function (prev, curr) {
     var arr = curr.match(/(.*?)\[(.*?)\]/)
     if (arr) {
-      return prev && prev[arr[1]][arr[2]]
+      return prev && prev[arr[1]] && prev[arr[1]][arr[2]]
     } else {
       return prev && prev[curr]
     }

--- a/test/expression.js
+++ b/test/expression.js
@@ -39,6 +39,8 @@ test('arrays in expression', function (t) {
   }
   t.strictEqual(objectGet(element, 'children[0].one'), 1)
   t.strictEqual(objectGet(element, 'children[1].children[0].three'), 3)
+  t.strictEqual(objectGet(element, 'otherChildren[0].four'), undefined)
+  t.strictEqual(objectGet(element, 'children[1].otherChildren[0].five'), undefined)
   t.end()
 })
 


### PR DESCRIPTION
Fixes the following problems which throws a runtime exception:
``` JavaScript
object-get({}, 'children[1].foo')
object-get({ children: [{}]}, 'children[0].children[0].foo')
```

